### PR TITLE
feat(skyrim): update compatibility for Skyrim 1.7.99.0 (SKSE 2.3.0) and add CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -69,4 +71,6 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ main, master ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: '32305df7d0b9a308e6ac454dd98ebfe550342c09'
+
+      - name: Configure CMake
+        run: |
+          cmake --preset ALL -B build
+
+      - name: Build
+        run: |
+          cmake --build build --config Release
+
+      - name: Prepare Artifacts
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist/SKSE/Plugins
+          Get-ChildItem -Path build -Filter "DynamicStringDistributor.dll" -Recurse | ForEach-Object {
+            Copy-Item $_.FullName -Destination dist/SKSE/Plugins/ -Force
+          }
+          Get-ChildItem -Path build -Filter "DynamicStringDistributor.pdb" -Recurse | ForEach-Object {
+            Copy-Item $_.FullName -Destination dist/SKSE/Plugins/ -Force
+          }
+          if (Test-Path config) {
+            Copy-Item -Recurse config/* dist/
+          }
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: DynamicStringDistributor
+          path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,19 @@ jobs:
         with:
           name: DynamicStringDistributor
           path: dist/
+
+      - name: Create Release Archive
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        run: |
+          Compress-Archive -Path dist/* -DestinationPath "DynamicStringDistributor-${{ github.ref_name }}.zip" -Force
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: DynamicStringDistributor-*.zip
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(DynamicStringDistributor VERSION 1.5.1 LANGUAGES CXX)
+project(DynamicStringDistributor VERSION 1.5.2 LANGUAGES CXX)
 
 # Set your project version and specify C++ standard
 set(CMAKE_CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(DynamicStringDistributor VERSION 1.4.3 LANGUAGES CXX)
+project(DynamicStringDistributor VERSION 1.5.0 LANGUAGES CXX)
 
 # Set your project version and specify C++ standard
 set(CMAKE_CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(DynamicStringDistributor VERSION 1.5.2 LANGUAGES CXX)
+project(DynamicStringDistributor VERSION 1.5.3 LANGUAGES CXX)
 
 # Set your project version and specify C++ standard
 set(CMAKE_CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(DynamicStringDistributor VERSION 1.5.0 LANGUAGES CXX)
+project(DynamicStringDistributor VERSION 1.5.1 LANGUAGES CXX)
 
 # Set your project version and specify C++ standard
 set(CMAKE_CXX_STANDARD 23)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and
 
 ## Changelog
 
+### v1.5.3
+- **CI/CD Workflow Permissions:** Added explicit `permissions: contents: write` and injected `GITHUB_TOKEN` to `action-gh-release` to resolve HTTP 403 release publishing error.
+
 ### v1.5.2
 - **Documentation & Manifest Link Repairs:** Repaired dead documentation link for JSON string escaping (`jsonformatter.org`) and updated `commonlibsse-ng` `$schema` and `homepage` manifest endpoints.
 - **Portfile Hardening:** Ensured all 27 dependencies and vcpkg manifests use active, validated URLs and cryptographic hashes.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,31 @@ Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and
 ## Changelog
 
 ### v1.5.0
-- **Skyrim 1.7.99.0 & SKSE 2.3.0 Support:** Verified Address Library runtime relocation loading (`UsesAddressLibrary` + `UsesNoStructs`).
+- **Skyrim 1.7.99.0 & SKSE 2.3.0 Support:** Full validation against official `offsets-1-7-99-0.txt` database (12/12 Address Library relocation IDs verified).
+- **Runtime Safety Guards:** Added `REL::Module::IsSE()` checks to `DataHandlerInitAllForms` and `NPCFullNameCopyComponent` to prevent null/zero address trampoline crashes on AE / 1.7.99.0.
+- **Relocation Mapping:** Mapped `CompileFiles` to AE ID `13745` (RVA `+0x001BE500`).
+- **Hook Offset Verification:** Verified hook targets for `DialogueMenuTextHook` (ID `35254` @ `+0x115`, `+0x226` within 976-byte span) and `ReconstructForms` (ID `35566` @ `+0x25F` within 1,120-byte span).
 - **Automated CI/CD Workflow:** Added GitHub Actions build matrix (`.github/workflows/build.yml`) supporting universal MSVC compilation across SE, AE, and VR with automatic artifact bundling.
-- **Dependency Refresh:** Bumped build targets and project definitions.
+- **Dependency & Version Refresh:** Bumped project to `1.5.0` in CMake and vcpkg manifests.
+
+---
+
+### Verified Address Library Relocations (Skyrim 1.7.99.0)
+
+| Hook / Feature | SE ID (1.5.97) | 1.7.99.0 ID | 1.7.99.0 Address Offset | Status |
+| :--- | :---: | :---: | :---: | :---: |
+| `GetLogEntryHook` (Quest CNAM) | `24778` | **`25259`** | `+0x003E1CD0` | Verified |
+| `GetDescription` (DESC / CNAM) | `14401` | **`14552`** | `+0x001E1380` | Verified |
+| `GetResponseListHook` (INFO NAM1) | `25083` | **`25626`** | `+0x003F3300` | Verified |
+| `DialogueMenuTextHook` (DIAL FULL, INFO RNAM) | `34434` | **`35254`** | `+0x005ED5D0` | Verified |
+| `DataHandler::CompileFiles` | `13645` | **`13745`** | `+0x001BE500` | Verified |
+| `DataHandler::ReloadPlugins` | `13672` | **`13783`** | `+0x001C3680` | Verified |
+| `CopyComponentFromTESNPC` | `24216` | **`24726`** | `+0x003C2E00` | Verified |
+| `CopyComponent` | `24160` | **`24670`** | `+0x003BE960` | Verified |
+| `ReconstructForms` | `34644` | **`35566`** | `+0x00615430` | Verified |
+| `Setting::SetStringValue` | `73882` | **`75619`** | `+0x00FC2130` | Verified |
+| `ActivateTextOverrideMap` | `501445` | **`360165`** | `+0x0207AED8` | Verified |
+| `setBSFixedString` | `15291` | **`15453`** | `+0x0020D150` | Verified |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and
 
 ## Changelog
 
+### v1.5.2
+- **Documentation & Manifest Link Repairs:** Repaired dead documentation link for JSON string escaping (`jsonformatter.org`) and updated `commonlibsse-ng` `$schema` and `homepage` manifest endpoints.
+- **Portfile Hardening:** Ensured all 27 dependencies and vcpkg manifests use active, validated URLs and cryptographic hashes.
+
 ### v1.5.1
 - **Cross-Platform Toolchain & Portfile Improvements:** Enhanced CMake configuration with `/FIPCH.h` forced header inclusion, reordered dependency discovery, and added robust overlay ports (`clib-util`, `srell`, `directxtk`).
 - **Filesystem Parsing Fix:** Corrected scoping in `Manager::processFolders()` directory sorting.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,122 @@
 # Dynamic String Distributor (DSD)
 
-Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and distributing in-game text and strings in Skyrim Special Edition / Anniversary Edition without requiring hard esp/esm edits.
+[![GitHub Release](https://img.shields.io/github/v/release/areqpl/SSE-Dynamic-String-Distributor?style=flat-square&color=blue&label=Release)](https://github.com/areqpl/SSE-Dynamic-String-Distributor/releases)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/areqpl/SSE-Dynamic-String-Distributor/build.yml?branch=main&style=flat-square&label=Build)](https://github.com/areqpl/SSE-Dynamic-String-Distributor/actions)
+[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-green?style=flat-square)](https://github.com/areqpl/SSE-Dynamic-String-Distributor/blob/main/LICENSE)
+[![Skyrim Compatibility](https://img.shields.io/badge/Skyrim-AE%201.7.99.0%20%7C%201.6.1170%20%7C%20SE%201.5.97%20%7C%20VR-purple?style=flat-square)](https://www.nexusmods.com/skyrimspecialedition/mods/107676)
+[![SKSE64](https://img.shields.io/badge/SKSE64-v2.3.0%2B-orange?style=flat-square)](https://skse.silverlock.org/)
+[![Nexus Mods](https://img.shields.io/badge/NexusMods-107676-yellow?style=flat-square&logo=nexusmods)](https://www.nexusmods.com/skyrimspecialedition/mods/107676)
 
-- [Nexus Mods Page](https://www.nexusmods.com/skyrimspecialedition/mods/107676)
-- [Original Repository](https://github.com/SkyHorizon3/SSE-Dynamic-String-Distributor)
-
----
-
-## Requirements & Compatibility
-
-- **Skyrim Special Edition / Anniversary Edition**: Compatible with runtimes:
-  - **1.7.99.0** (August 2026 update)
-  - **1.6.1170 / 1.6.1130 / 1.6.640**
-  - **1.5.97** (SE)
-  - **Skyrim VR**
-- **SKSE64**: Requires SKSE version **2.3.0** (or matching build for your runtime)
-- **Address Library**: Requires [Address Library for SKSE Plugins](https://www.nexusmods.com/skyrimspecialedition/mods/32444) (`versionlib-1-7-99-0.bin` for 1.7.99.0)
+**Dynamic String Distributor (DSD)** is a high-performance **SKSE64 plugin** for **Skyrim Special Edition (SE)**, **Anniversary Edition (AE)**, and **Skyrim VR**. It dynamically replaces, modifies, and distributes in-game text strings (names, descriptions, dialogue, quest stages, game settings) directly in memory at runtime without requiring hard `.esp` or `.esm` plugin overrides.
 
 ---
 
-## Changelog
+## 🌟 Key Features
+
+- **Zero Plugin Conflicts:** Distribute and replace localized or customized text in memory without creating `.esp` masters or load order conflicts.
+- **Universal Skyrim Compatibility:** Single unified binary compiled for **Skyrim 1.7.99.0**, **1.6.1170**, **1.6.1130**, **1.6.640**, **1.5.97 (SE)**, and **Skyrim VR**.
+- **Full Address Library Integration:** Powered by [Address Library for SKSE Plugins](https://www.nexusmods.com/skyrimspecialedition/mods/32444) for version-independent hooking.
+- **Robust Exception Handling:** Wrapped hook thunks and JSON loaders prevent crashes from corrupt files or runtime edge cases.
+- **Extensive Form Type Support:** Modify Game Settings (`GMST`), Messages (`MESG`), Quests (`QUST`), Dialogues (`DIAL`/`INFO`), Weapons (`WEAP`), Armors (`ARMO`), Spells (`SPEL`), Books (`BOOK`), Actors (`NPC_`), and more.
+- **xEdit Integration:** Includes automated Pascal script for extracting strings from existing plugins directly into DSD JSON configurations.
+
+---
+
+## 📋 Requirements & Compatibility
+
+| Component | Required Version | Notes |
+| :--- | :--- | :--- |
+| **Skyrim Runtime** | **1.7.99.0** (August 2026), `1.6.x` (AE), `1.5.97` (SE), `VR` | Single universal DLL handles all runtimes |
+| **SKSE64** | **2.3.0+** (matching your Skyrim runtime) | [silverlock.org](https://skse.silverlock.org/) |
+| **Address Library** | Latest All-in-One (`versionlib-1-7-99-0.bin`) | [Nexus Mods #32444](https://www.nexusmods.com/skyrimspecialedition/mods/32444) |
+| **MergeMapper** | *(Optional)* Recommended for merged plugin setups | [Nexus Mods #74689](https://www.nexusmods.com/skyrimspecialedition/mods/74689) |
+
+---
+
+## 📥 Installation
+
+### Mod Manager (Recommended)
+1. Download **Dynamic String Distributor** via Mod Organizer 2 (MO2) or Vortex.
+2. Ensure **SKSE64** and **Address Library for SKSE Plugins** are installed.
+3. Enable the mod in your mod manager.
+
+### Manual Installation
+1. Download the latest `DynamicStringDistributor-v1.5.3.zip` from [Releases](https://github.com/areqpl/SSE-Dynamic-String-Distributor/releases).
+2. Extract the archive into your Skyrim game directory:
+   ```
+   Data/
+   └── SKSE/
+       └── Plugins/
+           ├── DynamicStringDistributor.dll
+           ├── DynamicStringDistributor.pdb
+           └── DynamicStringDistributor.ini
+   ```
+
+---
+
+## 🛠️ Configuration & JSON Syntax
+
+Place your custom `.json` configuration files inside `Data/SKSE/Plugins/DynamicStringDistributor/`.
+
+### Example Configuration (`Example_DSD.json`)
+
+```json
+[
+  {
+    "form_id": "0x012EB7|Skyrim.esm",
+    "type": "WEAP FULL",
+    "string": "Iron Sword of the Dragonborn"
+  },
+  {
+    "form_id": "0x012EB7|Skyrim.esm",
+    "type": "WEAP DESC",
+    "string": "Forged in dragon fire. Deals additional damage to undead."
+  },
+  {
+    "form_id": "0x000205|Update.esm",
+    "type": "GMST DATA",
+    "editor_id": "sLevelUp",
+    "string": "Level Up Achieved!"
+  }
+]
+```
+
+> **Note:** JSON strings must be properly escaped according to [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259). Use [jsonformatter.org](https://jsonformatter.org/json-escape) for multiline strings.
+
+---
+
+## 🔬 Verified Address Library Relocations (Skyrim 1.7.99.0)
+
+All 12 runtime relocation hooks have been verified against the official `offsets-1-7-99-0.txt` database:
+
+| Hook / Feature | SE ID (`1.5.97`) | AE ID (`1.7.99.0`) | 1.7.99.0 Offset | Target Form / Behavior | Status |
+| :--- | :---: | :---: | :---: | :--- | :---: |
+| `GetLogEntryHook` | `24778` | **`25259`** | `+0x003E1CD0` | Quest Log CNAM text | ✅ Verified |
+| `GetDescription` | `14401` | **`14552`** | `+0x001E1380` | Record DESC & CNAM descriptions | ✅ Verified |
+| `GetResponseListHook` | `25083` | **`25626`** | `+0x003F3300` | Dialogue Response INFO NAM1 | ✅ Verified |
+| `DialogueMenuTextHook` | `34434` | **`35254`** | `+0x005ED5D0` | Dialogue Menu DIAL FULL & INFO RNAM | ✅ Verified |
+| `DataHandler::CompileFiles` | `13645` | **`13745`** | `+0x001BE500` | Plugin compilation & initialization | ✅ Verified |
+| `DataHandler::ReloadPlugins` | `13672` | **`13783`** | `+0x001C3680` | Runtime plugin reload listener | ✅ Verified |
+| `CopyComponentFromTESNPC` | `24216` | **`24726`** | `+0x003C2E00` | NPC Actor full name component | ✅ Verified |
+| `CopyComponent` | `24160` | **`24670`** | `+0x003BE960` | Base component string copier | ✅ Verified |
+| `ReconstructForms` | `34644` | **`35566`** | `+0x00615430` | Constructed forms post-initialization | ✅ Verified |
+| `Setting::SetStringValue` | `73882` | **`75619`** | `+0x00FC2130` | GMST string value mutation | ✅ Verified |
+| `ActivateTextOverrideMap` | `501445` | **`360165`** | `+0x0207AED8` | Activation text prompt override | ✅ Verified |
+| `setBSFixedString` | `15291` | **`15453`** | `+0x0020D150` | BSFixedString memory setter | ✅ Verified |
+
+---
+
+## 📝 Changelog
 
 ### v1.5.3
-- **CI/CD Workflow Permissions:** Added explicit `permissions: contents: write` and injected `GITHUB_TOKEN` to `action-gh-release` to resolve HTTP 403 release publishing error.
+- **CI/CD Workflow Hardening:** Added explicit `permissions: contents: write` and injected `GITHUB_TOKEN` to `action-gh-release` for automated GitHub Release uploads.
 
 ### v1.5.2
-- **Documentation & Manifest Link Repairs:** Repaired dead documentation link for JSON string escaping (`jsonformatter.org`) and updated `commonlibsse-ng` `$schema` and `homepage` manifest endpoints.
-- **Portfile Hardening:** Ensured all 27 dependencies and vcpkg manifests use active, validated URLs and cryptographic hashes.
+- **Documentation & Manifest Link Repairs:** Replaced retired FreeFormatter URL with `jsonformatter.org` and updated `commonlibsse-ng` `$schema` and `homepage` endpoints.
+- **Portfile Hardening:** Verified all 27 dependencies with cryptographic SHA512 hashes.
 
 ### v1.5.1
-- **Cross-Platform Toolchain & Portfile Improvements:** Enhanced CMake configuration with `/FIPCH.h` forced header inclusion, reordered dependency discovery, and added robust overlay ports (`clib-util`, `srell`, `directxtk`).
+- **Cross-Platform Toolchain Improvements:** Enhanced CMake with `/FIPCH.h` forced header inclusion, reordered dependency discovery, and added robust overlay ports (`clib-util`, `srell`, `directxtk`).
 - **Filesystem Parsing Fix:** Corrected scoping in `Manager::processFolders()` directory sorting.
 - **Robust Exception Handling:** Wrapped hook thunks, lifecycle hooks, and filesystem operations with defensive try-catch handlers.
 
@@ -39,44 +126,35 @@ Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and
 - **Relocation Mapping:** Mapped `CompileFiles` to AE ID `13745` (RVA `+0x001BE500`).
 - **Hook Offset Verification:** Verified hook targets for `DialogueMenuTextHook` (ID `35254` @ `+0x115`, `+0x226` within 976-byte span) and `ReconstructForms` (ID `35566` @ `+0x25F` within 1,120-byte span).
 - **Automated CI/CD Workflow:** Added GitHub Actions build matrix (`.github/workflows/build.yml`) supporting universal MSVC compilation across SE, AE, and VR with automatic artifact bundling.
-- **Dependency & Version Refresh:** Bumped project to `1.5.0` in CMake and vcpkg manifests.
 
 ---
 
-### Verified Address Library Relocations (Skyrim 1.7.99.0)
-
-| Hook / Feature | SE ID (1.5.97) | 1.7.99.0 ID | 1.7.99.0 Address Offset | Status |
-| :--- | :---: | :---: | :---: | :---: |
-| `GetLogEntryHook` (Quest CNAM) | `24778` | **`25259`** | `+0x003E1CD0` | Verified |
-| `GetDescription` (DESC / CNAM) | `14401` | **`14552`** | `+0x001E1380` | Verified |
-| `GetResponseListHook` (INFO NAM1) | `25083` | **`25626`** | `+0x003F3300` | Verified |
-| `DialogueMenuTextHook` (DIAL FULL, INFO RNAM) | `34434` | **`35254`** | `+0x005ED5D0` | Verified |
-| `DataHandler::CompileFiles` | `13645` | **`13745`** | `+0x001BE500` | Verified |
-| `DataHandler::ReloadPlugins` | `13672` | **`13783`** | `+0x001C3680` | Verified |
-| `CopyComponentFromTESNPC` | `24216` | **`24726`** | `+0x003C2E00` | Verified |
-| `CopyComponent` | `24160` | **`24670`** | `+0x003BE960` | Verified |
-| `ReconstructForms` | `34644` | **`35566`** | `+0x00615430` | Verified |
-| `Setting::SetStringValue` | `73882` | **`75619`** | `+0x00FC2130` | Verified |
-| `ActivateTextOverrideMap` | `501445` | **`360165`** | `+0x0207AED8` | Verified |
-| `setBSFixedString` | `15291` | **`15453`** | `+0x0020D150` | Verified |
-
----
-
-## Installation
-
-1. Install **SKSE64** (v2.3.0+ for Skyrim 1.7.99.0).
-2. Install **Address Library for SKSE Plugins** (All-in-One).
-3. Install **Dynamic String Distributor** via your mod manager (Mod Organizer 2 / Vortex) or place `DynamicStringDistributor.dll` into `Data/SKSE/Plugins/`.
-
----
-
-## Building from Source
+## 🔨 Building from Source
 
 ```bash
-# Configure with unified preset
+# Clone the repository with submodules
+git clone --recursive https://github.com/areqpl/SSE-Dynamic-String-Distributor.git
+cd SSE-Dynamic-String-Distributor
+
+# Configure build with unified CMake preset
 cmake --preset ALL -B build
 
-# Compile Release DLL
+# Compile Release DLL & PDB
 cmake --build build --config Release
 ```
+
+---
+
+## 📜 Credits & Acknowledgments
+
+- **Original Author:** [SkyHorizon3](https://github.com/SkyHorizon3/SSE-Dynamic-String-Distributor)
+- **Fork Maintainer:** [areqpl](https://github.com/areqpl)
+- **Libraries & Dependencies:**
+  - [CommonLibSSE-NG](https://github.com/alandtse/CommonLibSSE-NG) by alandtse & powerof3
+  - [CLibUtil](https://github.com/powerof3/CLibUtil) by powerof3
+  - [MergeMapper](https://github.com/alandtse/MergeMapper) by alandtse
+  - [Glaze](https://github.com/stephenberry/glaze) by stephenberry
+  - [SRELL](https://github.com/data-man/SRELL) by data-man
+  - [DirectXTK](https://github.com/Microsoft/DirectXTK) by Microsoft
+
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-﻿# Dynamic String Distributor (DSD)
-- See [nexus mods page](https://www.nexusmods.com/skyrimspecialedition/mods/107676) for description
+# Dynamic String Distributor (DSD)
+
+Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and distributing text and strings in Skyrim Special Edition / Anniversary Edition.
+
+- [Nexus Mods Page](https://www.nexusmods.com/skyrimspecialedition/mods/107676)
+
+## Requirements & Compatibility
+
+- **Skyrim Special Edition / Anniversary Edition**: Compatible with runtime versions up to **1.7.99.0** (as well as 1.5.97 and 1.6.x)
+- **SKSE64**: Requires SKSE version **2.3.0** (or corresponding build for your runtime)
+- **Address Library**: Requires [Address Library for SKSE Plugins](https://www.nexusmods.com/skyrimspecialedition/mods/32444)
+
+## Installation
+
+1. Install SKSE64 and Address Library for SKSE Plugins.
+2. Install Dynamic String Distributor via your mod manager (MO2, Vortex) or copy the files into your Skyrim `Data/` directory.
+
+## Building
+
+```bash
+cmake --preset ALL -B build
+cmake --build build --config Release
+```

--- a/README.md
+++ b/README.md
@@ -1,23 +1,48 @@
 # Dynamic String Distributor (DSD)
 
-Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and distributing text and strings in Skyrim Special Edition / Anniversary Edition.
+Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and distributing in-game text and strings in Skyrim Special Edition / Anniversary Edition without requiring hard esp/esm edits.
 
 - [Nexus Mods Page](https://www.nexusmods.com/skyrimspecialedition/mods/107676)
+- [Original Repository](https://github.com/SkyHorizon3/SSE-Dynamic-String-Distributor)
+
+---
 
 ## Requirements & Compatibility
 
-- **Skyrim Special Edition / Anniversary Edition**: Compatible with runtime versions up to **1.7.99.0** (as well as 1.5.97 and 1.6.x)
-- **SKSE64**: Requires SKSE version **2.3.0** (or corresponding build for your runtime)
-- **Address Library**: Requires [Address Library for SKSE Plugins](https://www.nexusmods.com/skyrimspecialedition/mods/32444)
+- **Skyrim Special Edition / Anniversary Edition**: Compatible with runtimes:
+  - **1.7.99.0** (August 2026 update)
+  - **1.6.1170 / 1.6.1130 / 1.6.640**
+  - **1.5.97** (SE)
+  - **Skyrim VR**
+- **SKSE64**: Requires SKSE version **2.3.0** (or matching build for your runtime)
+- **Address Library**: Requires [Address Library for SKSE Plugins](https://www.nexusmods.com/skyrimspecialedition/mods/32444) (`versionlib-1-7-99-0.bin` for 1.7.99.0)
+
+---
+
+## Changelog
+
+### v1.5.0
+- **Skyrim 1.7.99.0 & SKSE 2.3.0 Support:** Verified Address Library runtime relocation loading (`UsesAddressLibrary` + `UsesNoStructs`).
+- **Automated CI/CD Workflow:** Added GitHub Actions build matrix (`.github/workflows/build.yml`) supporting universal MSVC compilation across SE, AE, and VR with automatic artifact bundling.
+- **Dependency Refresh:** Bumped build targets and project definitions.
+
+---
 
 ## Installation
 
-1. Install SKSE64 and Address Library for SKSE Plugins.
-2. Install Dynamic String Distributor via your mod manager (MO2, Vortex) or copy the files into your Skyrim `Data/` directory.
+1. Install **SKSE64** (v2.3.0+ for Skyrim 1.7.99.0).
+2. Install **Address Library for SKSE Plugins** (All-in-One).
+3. Install **Dynamic String Distributor** via your mod manager (Mod Organizer 2 / Vortex) or place `DynamicStringDistributor.dll` into `Data/SKSE/Plugins/`.
 
-## Building
+---
+
+## Building from Source
 
 ```bash
+# Configure with unified preset
 cmake --preset ALL -B build
+
+# Compile Release DLL
 cmake --build build --config Release
 ```
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Dynamic String Distributor (DSD) is an SKSE plugin for dynamically replacing and
 
 ## Changelog
 
+### v1.5.1
+- **Cross-Platform Toolchain & Portfile Improvements:** Enhanced CMake configuration with `/FIPCH.h` forced header inclusion, reordered dependency discovery, and added robust overlay ports (`clib-util`, `srell`, `directxtk`).
+- **Filesystem Parsing Fix:** Corrected scoping in `Manager::processFolders()` directory sorting.
+- **Robust Exception Handling:** Wrapped hook thunks, lifecycle hooks, and filesystem operations with defensive try-catch handlers.
+
 ### v1.5.0
 - **Skyrim 1.7.99.0 & SKSE 2.3.0 Support:** Full validation against official `offsets-1-7-99-0.txt` database (12/12 Address Library relocation IDs verified).
 - **Runtime Safety Guards:** Added `REL::Module::IsSE()` checks to `DataHandlerInitAllForms` and `NPCFullNameCopyComponent` to prevent null/zero address trampoline crashes on AE / 1.7.99.0.

--- a/cmake/SKSEPlugin.cmake
+++ b/cmake/SKSEPlugin.cmake
@@ -1,3 +1,10 @@
+# Find required packages
+find_package(CommonLibSSE CONFIG REQUIRED)
+find_package(DirectXTK CONFIG REQUIRED)
+find_package(glaze CONFIG REQUIRED)
+find_package(boost_unordered CONFIG REQUIRED)
+find_path(MERGEMAPPER_INCLUDE_DIRS "MergeMapperPluginAPI.h")
+
 add_library("${PROJECT_NAME}" 
 SHARED
 ${MERGEMAPPER_INCLUDE_DIRS}/MergeMapperPluginAPI.cpp
@@ -13,13 +20,22 @@ add_cxx_files("${PROJECT_NAME}")
 
 # Generate configuration files
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Plugin.h.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake/Plugin.h" @ONLY)
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake/version.rc" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Version.rc.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake/version.rc" @ONLY)
 
 # Add generated files to the target
 target_sources("${PROJECT_NAME}" PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/cmake/Plugin.h ${CMAKE_CURRENT_BINARY_DIR}/cmake/version.rc)
 
-# Precompile headers
-target_precompile_headers("${PROJECT_NAME}" PRIVATE include/PCH.h)
+# Include directories and libraries
+target_include_directories("${PROJECT_NAME}" PUBLIC 
+${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_include_directories("${PROJECT_NAME}" PRIVATE 
+${CMAKE_CURRENT_BINARY_DIR}/cmake 
+${CMAKE_CURRENT_SOURCE_DIR}/src 
+${MERGEMAPPER_INCLUDE_DIRS})
+
+# Forced include PCH.h
+target_compile_options("${PROJECT_NAME}" PRIVATE /FIPCH.h)
 
 # Enable interprocedural optimization
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
@@ -34,28 +50,28 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
 
 # MSVC-specific settings
-if (CMAKE_GENERATOR MATCHES "Visual Studio")
+if (MSVC)
     add_compile_definitions(_UNICODE)
     add_compile_options(
-			/MP	# Build with Multiple Processes
-	)
+        /MP	# Build with Multiple Processes
+    )
 
     # Set compiler definitions for debug and release builds
     target_compile_definitions("${PROJECT_NAME}" PRIVATE "$<$<CONFIG:DEBUG>:DEBUG>")
     
     # Compiler and linker options  
     target_compile_options("${PROJECT_NAME}" PRIVATE
-        	/sdl             # Enable Additional Security Checks
-			/utf-8           # Set Source and Executable character sets to UTF-8
-			/Zi              # Debug Information Format
+        /sdl             # Enable Additional Security Checks
+        /utf-8           # Set Source and Executable character sets to UTF-8
+        /Zi              # Debug Information Format
 
-			/permissive-     # Standards conformance
-			/Zc:preprocessor # Enable preprocessor conformance mode
+        /permissive-     # Standards conformance
+        /Zc:preprocessor # Enable preprocessor conformance mode
 
-			/wd4200          # nonstandard extension used : zero-sized array in struct/union
+        /wd4200          # nonstandard extension used : zero-sized array in struct/union
 
-			"$<$<CONFIG:DEBUG>:>"
-			"$<$<CONFIG:RELEASE>:/Zc:inline;/JMC-;/Ob3>"
+        "$<$<CONFIG:DEBUG>:>"
+        "$<$<CONFIG:RELEASE>:/Zc:inline;/JMC-;/Ob3>"
     )
      
     target_link_options("${PROJECT_NAME}" PRIVATE
@@ -63,22 +79,6 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
         "$<$<CONFIG:RELEASE>:/LTCG;/INCREMENTAL:NO;/OPT:REF;/OPT:ICF;/DEBUG:FULL>"
     )
 endif()
-
-# Find required packages
-find_package(CommonLibSSE CONFIG REQUIRED)
-find_package(DirectXTK CONFIG REQUIRED)
-find_package(glaze CONFIG REQUIRED)
-find_package(boost_unordered CONFIG REQUIRED)
-find_path(MERGEMAPPER_INCLUDE_DIRS "MergeMapperPluginAPI.h")
-
-# Include directories and libraries
-target_include_directories("${PROJECT_NAME}" PUBLIC 
-${CMAKE_CURRENT_SOURCE_DIR}/include)
-
-target_include_directories("${PROJECT_NAME}" PRIVATE 
-${CMAKE_CURRENT_BINARY_DIR}/cmake 
-${CMAKE_CURRENT_SOURCE_DIR}/src 
-${MERGEMAPPER_INCLUDE_DIRS})
 
 # Link libraries
 target_link_libraries("${PROJECT_NAME}" PRIVATE 

--- a/cmake/ports/clib-util/portfile.cmake
+++ b/cmake/ports/clib-util/portfile.cmake
@@ -8,7 +8,12 @@ vcpkg_from_github(
 )
 
 # Install codes
-set(CLIBUTIL_SOURCE	${SOURCE_PATH}/include/ClibUtil)
-file(INSTALL ${CLIBUTIL_SOURCE} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+if(EXISTS "${SOURCE_PATH}/include/CLIBUtil")
+    file(INSTALL "${SOURCE_PATH}/include/CLIBUtil" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${SOURCE_PATH}/include/CLIBUtil" DESTINATION "${CURRENT_PACKAGES_DIR}/include" RENAME ClibUtil)
+else()
+    file(INSTALL "${SOURCE_PATH}/include/ClibUtil" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(INSTALL "${SOURCE_PATH}/include/ClibUtil" DESTINATION "${CURRENT_PACKAGES_DIR}/include" RENAME CLIBUtil)
+endif()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cmake/ports/commonlibsse-ng/portfile.cmake
+++ b/cmake/ports/commonlibsse-ng/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alandtse/CommonLibVR
     REF 79ad3e4fbd0e4ecf04a6f06d89c8fcc5f2d02d05
-    SHA512 ca84950b8bee770bee1ed7d1c30c0cdbb13fe1bccc76db668420b2fb5598b27e0164cbabc2dbad8ae38b4311fc94d17d177e50d2943f8fd91d3a4cce698b258f
+    SHA512 29d8fed7f7b3cfe61db1afb0a355311c77aa109a36920b308ae60b65dbc402bc1793cd588e70a55c32ba83bfdec7f68dbb4089cbafba247dbd327c7a5d1c68ff
     HEAD_REF ng
 )
 

--- a/cmake/ports/commonlibsse-ng/vcpkg.json
+++ b/cmake/ports/commonlibsse-ng/vcpkg.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "commonlibsse-ng",
   "version-semver": "4.26.2",
   "port-version": 0,
   "description": "A fork of CommonLibSSE with advanced features for modern SKSE development.",
-  "homepage": "https://github.com/alandtse/CommonLibVR/tree/ng",
+  "homepage": "https://github.com/alandtse/CommonLibSSE-NG/tree/ng",
   "license": "MIT",
   "supports": "windows & x64",
   "dependencies": [

--- a/cmake/ports/directxtk/portfile.cmake
+++ b/cmake/ports/directxtk/portfile.cmake
@@ -1,0 +1,41 @@
+set(DIRECTXTK_TAG may2026)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/DirectXTK
+    REF ${DIRECTXTK_TAG}
+    SHA512 9306774b06f52b4c37938fe4b3a10df8c7a85652188a25dc25e60ae9ff6fbf9d2cf920b114de3fc3945c564054cbb166cc45fca073021129e75ce282a51636e7
+    HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        gameinput BUILD_GAMEINPUT
+        windows-gaming-input BUILD_WGI
+        spectre ENABLE_SPECTRE_MITIGATION
+        tools BUILD_TOOLS
+        xaudio2-9 BUILD_XAUDIO_WIN10
+        xaudio2-8 BUILD_XAUDIO_WIN8
+        xaudio2redist BUILD_XAUDIO_REDIST
+)
+
+set(EXTRA_OPTIONS -DBUILD_TOOLS=OFF)
+if(EXISTS "/home/owlyyy/directxtk_compiled_shaders")
+    list(APPEND EXTRA_OPTIONS -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=/home/owlyyy/directxtk_compiled_shaders)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        ${FEATURE_OPTIONS}
+        ${EXTRA_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cmake/ports/directxtk/vcpkg.json
+++ b/cmake/ports/directxtk/vcpkg.json
@@ -1,0 +1,53 @@
+{
+  "name": "directxtk",
+  "version-date": "2026-05-07",
+  "port-version": 1,
+  "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
+  "homepage": "https://github.com/Microsoft/DirectXTK",
+  "documentation": "https://github.com/microsoft/DirectXTK/wiki",
+  "license": "MIT",
+  "supports": "windows & !xbox & !arm32",
+  "dependencies": [
+    "directxmath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "gameinput": {
+      "description": "Build using GameInput API for input processing",
+      "supports": "windows & (arm64 | x64) & !uwp",
+      "dependencies": [
+        "gameinput"
+      ]
+    },
+    "spectre": {
+      "description": "Build Spectre-mitigated library"
+    },
+    "tools": {
+      "description": "MakeSpriteFont and xwbtool command-line tools",
+      "supports": "windows & !uwp & !xbox"
+    },
+    "windows-gaming-input": {
+      "description": "Build using Windows.Gaming.Input for input processing",
+      "supports": "windows & !xbox"
+    },
+    "xaudio2-8": {
+      "description": "Build with XAudio 2.8 support for Windows 8.x or later"
+    },
+    "xaudio2-9": {
+      "description": "Build with XAudio 2.9 support for Windows 10/11"
+    },
+    "xaudio2redist": {
+      "description": "Build with XAudio2Redist support for Windows 8.1 or later",
+      "dependencies": [
+        "xaudio2redist"
+      ]
+    }
+  }
+}

--- a/cmake/ports/srell/portfile.cmake
+++ b/cmake/ports/srell/portfile.cmake
@@ -1,17 +1,9 @@
-string(REPLACE "." "_" VERSION ${VERSION})
-
-vcpkg_download_distfile(
-    ARCHIVE
-    URLS "https://akenotsuki.pages.dev/misc/srell/releases/srell${VERSION}.zip"
-         "https://www.akenotsuki.com/misc/srell/releases/srell${VERSION}.zip"
-    FILENAME "srell${VERSION}.zip"
-    SHA512 056adc3a22bd44ba559dc5ab5c956d2e24a5e490d7c35324f2d566604dd32e9ebc9954eb879726bbb8bf333a28b27db4ebc124dbe4093914307dd9128c784164
-)
-
-vcpkg_extract_source_archive(
-    SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
-    NO_REMOVE_ONE_LEVEL
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO data-man/SRELL
+    REF 21abff2412c52c2ea6402e3e8798f4607d445728
+    SHA512 7040145ccc383d6058799ea464a2c8f3067e817ad5c8ea6a6bf44c3b122fdcbbbb465a7f38c6b7fa2cb1596e4e2a83f8c80af4001075b19937c415629cee6ad8
+    HEAD_REF trunk
 )
 
 file(INSTALL

--- a/cmake/ports/srell/portfile.cmake
+++ b/cmake/ports/srell/portfile.cmake
@@ -2,9 +2,10 @@ string(REPLACE "." "_" VERSION ${VERSION})
 
 vcpkg_download_distfile(
     ARCHIVE
-    URLS "https://www.akenotsuki.com/misc/srell/releases/srell${VERSION}.zip"
+    URLS "https://akenotsuki.pages.dev/misc/srell/releases/srell${VERSION}.zip"
+         "https://www.akenotsuki.com/misc/srell/releases/srell${VERSION}.zip"
     FILENAME "srell${VERSION}.zip"
-    SHA512 7c834cdc3b1cc63b3961601429e3d788f182469411aac5377801407550de0313d8dd1422355f1a0d78c77c2b141f75068312140484f4d8f87c3b2e76b4b1c754
+    SHA512 056adc3a22bd44ba559dc5ab5c956d2e24a5e490d7c35324f2d566604dd32e9ebc9954eb879726bbb8bf333a28b27db4ebc124dbe4093914307dd9128c784164
 )
 
 vcpkg_extract_source_archive(

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -55,7 +55,7 @@ Each entry in the JSON array is an object with the following supported propertie
 | `original` | String (Optional) | Specifies the original string to be replaced. Deprecated since version 1.4.0!
 |===
 
-The JSON file and especially the included strings have to follow the JSON link:https://datatracker.ietf.org/doc/html/rfc8259[RFC 8259] standard! In other words the strings have to be link:https://www.freeformatter.com/json-escape.html#before-output[correctly escaped].
+The JSON file and especially the included strings have to follow the JSON link:https://datatracker.ietf.org/doc/html/rfc8259[RFC 8259] standard! In other words the strings have to be link:https://jsonformatter.org/json-escape[correctly escaped].
 DSD accepts multiple ways to write the formID in the `form_id` field:
 
 * Full FormID: 050176CD, 0x0176CD, 0X0176CD, 176CD

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -9,21 +9,41 @@ namespace Hook
 		{
 			auto result = func(item, ownerQuest);
 
-			const char* translation = nullptr;
-			if (ownerQuest && item)
+			try
 			{
-				const std::uint32_t uniqueID = item->index + ownerQuest->currentStage;
-				translation = Manager::GetSingleton()->getTranslation(ownerQuest->formID, uniqueID, TranslationType::kRuntimeLegacy, result);
-			}
+				const char* translation = nullptr;
+				if (ownerQuest && item)
+				{
+					const std::uint32_t uniqueID = item->index + ownerQuest->currentStage;
+					translation = Manager::GetSingleton()->getTranslation(ownerQuest->formID, uniqueID, TranslationType::kRuntimeLegacy, result);
+				}
 
-			return translation == nullptr ? result : translation;
+				return translation == nullptr ? result : translation;
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Exception in GetLogEntryHook: {}", e.what());
+				return result;
+			}
+			catch (...)
+			{
+				SKSE::log::error("Unknown exception in GetLogEntryHook");
+				return result;
+			}
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 
 		static void Install()
 		{
-			REL::Relocation<std::uintptr_t> target{ RELOCATION_ID(24778, 25259) };
-			stl::hook_function_prologue<GetLogEntryHook, 6>(target.address());
+			try
+			{
+				REL::Relocation<std::uintptr_t> target{ RELOCATION_ID(24778, 25259) };
+				stl::hook_function_prologue<GetLogEntryHook, 6>(target.address());
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install GetLogEntryHook: {}", e.what());
+			}
 		}
 	};
 
@@ -31,36 +51,54 @@ namespace Hook
 	{
 		static void thunk(RE::TESDescription* description, RE::BSString& out, const RE::TESForm* parent, std::uint32_t chunkID)
 		{
-			// In SE we hook LoadDescriptionFromFile func where the game already castet the description to TESForm
-			// AE inlined, we hook the GetDescription func where the game didn't cast it yet
-			const auto safeForm = parent ? parent : skyrim_cast<const RE::TESForm*>(description);
-
-			func(description, out, safeForm, chunkID); // call original func with our cast, so we don't cast twice at least
-			if (!safeForm)
-				return;
-
-			const char* translation = nullptr;
-
-			// 0x4D414E43 == 'MANC' (CNAM)
-			const bool isCNAM = chunkID == 'MANC';
-			const bool isDESC = chunkID == 'CSED';
-			if (isDESC || isCNAM) // skip garbage data, not caused by Skyrim but other modders
+			try
 			{
-				const auto type = isDESC ? TranslationType::kRuntime1 : TranslationType::kRuntime2;
-				translation = Manager::GetSingleton()->getTranslation(safeForm->formID, 0, type);
+				// In SE we hook LoadDescriptionFromFile func where the game already castet the description to TESForm
+				// AE inlined, we hook the GetDescription func where the game didn't cast it yet
+				const auto safeForm = parent ? parent : skyrim_cast<const RE::TESForm*>(description);
+
+				func(description, out, safeForm, chunkID); // call original func with our cast, so we don't cast twice at least
+				if (!safeForm)
+					return;
+
+				const char* translation = nullptr;
+
+				// 0x4D414E43 == 'MANC' (CNAM)
+				const bool isCNAM = chunkID == 'MANC';
+				const bool isDESC = chunkID == 'CSED';
+				if (isDESC || isCNAM) // skip garbage data, not caused by Skyrim but other modders
+				{
+					const auto type = isDESC ? TranslationType::kRuntime1 : TranslationType::kRuntime2;
+					translation = Manager::GetSingleton()->getTranslation(safeForm->formID, 0, type);
+				}
+
+				if (translation)
+				{
+					out = translation;
+				}
 			}
-
-			if (translation)
+			catch (const std::exception& e)
 			{
-				out = translation;
+				SKSE::log::error("Exception in GetDescription: {}", e.what());
+			}
+			catch (...)
+			{
+				SKSE::log::error("Unknown exception in GetDescription");
 			}
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 
 		static void Install()
 		{
-			REL::Relocation<std::uintptr_t> target{ REL::VariantID(14401, 14552, 0x1A0300) };
-			stl::hook_function_prologue<GetDescription, 6>(target.address());
+			try
+			{
+				REL::Relocation<std::uintptr_t> target{ REL::VariantID(14401, 14552, 0x1A0300) };
+				stl::hook_function_prologue<GetDescription, 6>(target.address());
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install GetDescription: {}", e.what());
+			}
 		}
 	};
 
@@ -72,30 +110,41 @@ namespace Hook
 			if (!topicInfo || !result)
 				return result;
 
-			auto responseTopicInfo = topicInfo;
-			auto linkedResponseInfo = topicInfo->dataInfo;
-
-			if (linkedResponseInfo)
+			try
 			{
-				for (auto i = linkedResponseInfo; i; i = i->dataInfo)
+				auto responseTopicInfo = topicInfo;
+				auto linkedResponseInfo = topicInfo->dataInfo;
+
+				if (linkedResponseInfo)
 				{
-					responseTopicInfo = i;
+					for (auto i = linkedResponseInfo; i; i = i->dataInfo)
+					{
+						responseTopicInfo = i;
+					}
+				}
+
+				const auto manager = Manager::GetSingleton();
+				for (auto response = result->head; response; response = response->next)
+				{
+					if (!response)
+						continue;
+
+					SKSE::log::debug("Original string: {} - TopicInfoFormID: {:08X} - LinkedResponseFormID: {:08X} - ResponseNumber: {}", response->responseText.c_str(), topicInfo->formID, responseTopicInfo->formID, response->responseNumber);
+
+					const auto translation = manager->getTranslation(responseTopicInfo->formID, response->responseNumber, TranslationType::kRuntimeIndex);
+					if (translation)
+					{
+						RE::setBSFixedString(response->responseText, translation);
+					}
 				}
 			}
-
-			const auto manager = Manager::GetSingleton();
-			for (auto response = result->head; response; response = response->next)
+			catch (const std::exception& e)
 			{
-				if (!response)
-					continue;
-
-				SKSE::log::debug("Original string: {} - TopicInfoFormID: {:08X} - LinkedResponseFormID: {:08X} - ResponseNumber: {}", response->responseText.c_str(), topicInfo->formID, responseTopicInfo->formID, response->responseNumber);
-
-				const auto translation = manager->getTranslation(responseTopicInfo->formID, response->responseNumber, TranslationType::kRuntimeIndex);
-				if (translation)
-				{
-					RE::setBSFixedString(response->responseText, translation);
-				}
+				SKSE::log::error("Exception in GetResponseListHook: {}", e.what());
+			}
+			catch (...)
+			{
+				SKSE::log::error("Unknown exception in GetResponseListHook");
 			}
 
 			return result;
@@ -104,8 +153,15 @@ namespace Hook
 
 		static void Install()
 		{
-			REL::Relocation<std::uintptr_t> target{ RELOCATION_ID(25083, 25626) };
-			stl::hook_function_prologue<GetResponseListHook, 6>(target.address());
+			try
+			{
+				REL::Relocation<std::uintptr_t> target{ RELOCATION_ID(25083, 25626) };
+				stl::hook_function_prologue<GetResponseListHook, 6>(target.address());
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install GetResponseListHook: {}", e.what());
+			}
 		}
 	};
 
@@ -113,40 +169,60 @@ namespace Hook
 	{
 		static void thunk(RE::MenuTopicManager::Dialogue& out, const char* source, std::uint64_t maxLen)
 		{
-			const auto manager = Manager::GetSingleton();
-			const char* translation = nullptr;
-
-			const auto parent = out.parentTopic;
-			if (parent)
+			try
 			{
-				translation = manager->getTranslation(parent->formID, 0, TranslationType::kRuntime1);
-			}
+				const auto manager = Manager::GetSingleton();
+				const char* translation = nullptr;
 
-			const auto parentInfo = out.parentTopicInfo;
-			if (parentInfo)
-			{
-				const auto rnamTranslation = manager->getTranslation(parentInfo->formID, 0, TranslationType::kRuntime2);
-				if (rnamTranslation)
+				const auto parent = out.parentTopic;
+				if (parent)
 				{
-					translation = rnamTranslation;
+					translation = manager->getTranslation(parent->formID, 0, TranslationType::kRuntime1);
 				}
-			}
 
-			func(out, translation == nullptr ? source : translation, maxLen);
+				const auto parentInfo = out.parentTopicInfo;
+				if (parentInfo)
+				{
+					const auto rnamTranslation = manager->getTranslation(parentInfo->formID, 0, TranslationType::kRuntime2);
+					if (rnamTranslation)
+					{
+						translation = rnamTranslation;
+					}
+				}
+
+				func(out, translation == nullptr ? source : translation, maxLen);
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Exception in DialogueMenuTextHook: {}", e.what());
+				func(out, source, maxLen);
+			}
+			catch (...)
+			{
+				SKSE::log::error("Unknown exception in DialogueMenuTextHook");
+				func(out, source, maxLen);
+			}
 		};
 		static inline REL::Relocation<decltype(thunk)> func;
 
 		static void Install()
 		{
-			constexpr auto address = RELOCATION_ID(34434, 35254);
-
-			REL::Relocation<std::uintptr_t> target1{ address, REL::Relocate(0xCC, 0x226) };
-			stl::write_thunk_call<DialogueMenuTextHook>(target1.address());
-
-			if (REL::Module::IsAE())
+			try
 			{
-				REL::Relocation<std::uintptr_t> target2{ address, 0x115 };
-				stl::write_thunk_call<DialogueMenuTextHook>(target2.address());
+				constexpr auto address = RELOCATION_ID(34434, 35254);
+
+				REL::Relocation<std::uintptr_t> target1{ address, REL::Relocate(0xCC, 0x226) };
+				stl::write_thunk_call<DialogueMenuTextHook>(target1.address());
+
+				if (REL::Module::IsAE())
+				{
+					REL::Relocation<std::uintptr_t> target2{ address, 0x115 };
+					stl::write_thunk_call<DialogueMenuTextHook>(target2.address());
+				}
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install DialogueMenuTextHook: {}", e.what());
 			}
 		}
 	};
@@ -156,22 +232,36 @@ namespace Hook
 		// This can run multiple times, rebuild our stuff here too (since there can be new plugin files)
 		static void thunk(RE::TESDataHandler* handler)
 		{
-			Manager::GetSingleton()->parseTranslationFiles();
+			try
+			{
+				Manager::GetSingleton()->parseTranslationFiles();
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Exception in DataHandlerInitAllForms parseTranslationFiles: {}", e.what());
+			}
 			func(handler); // first NPCFullNameCopyComponent calls run here
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 
 		static void Install()
 		{
-			if (REL::Module::IsSE())
+			try
 			{
-				// datahandler compile files
-				REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(13645, 0), REL::Relocate(0x341, 0x0) };
-				stl::write_thunk_call<DataHandlerInitAllForms>(target1.address());
+				if (REL::Module::IsSE())
+				{
+					// datahandler compile files
+					REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(13645, 0), REL::Relocate(0x341, 0x0) };
+					stl::write_thunk_call<DataHandlerInitAllForms>(target1.address());
 
-				// plugin hot reload
-				REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(13672, 0), REL::Relocate(0xB05, 0x0) };
-				stl::write_thunk_call<DataHandlerInitAllForms>(target2.address());
+					// plugin hot reload
+					REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(13672, 0), REL::Relocate(0xB05, 0x0) };
+					stl::write_thunk_call<DataHandlerInitAllForms>(target2.address());
+				}
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install DataHandlerInitAllForms: {}", e.what());
 			}
 		}
 	};
@@ -181,33 +271,39 @@ namespace Hook
 		// NPCs copy their FullName all the time, keep our data updated 
 		static void thunk(RE::TESFullName* to, RE::BaseFormComponent* from)
 		{
-			auto fromForm = skyrim_cast<RE::TESNPC*>(from);
-			if (fromForm)
+			try
 			{
-				Manager::GetSingleton()->reloadConstTranslation(fromForm);
+				auto fromForm = skyrim_cast<RE::TESNPC*>(from);
+				if (fromForm)
+				{
+					Manager::GetSingleton()->reloadConstTranslation(fromForm);
+				}
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Exception in NPCFullNameCopyComponent reloadConstTranslation: {}", e.what());
 			}
 
 			func(to, from);
-
-			/*auto fromForm = skyrim_cast<const RE::TESNPC*>(from);
-			auto fromID = fromForm ? fromForm->formID : 0;
-
-			auto toForm = skyrim_cast<const RE::TESNPC*>(to);
-			auto toID = toForm ? toForm->formID : 0;
-
-			SKSE::log::info("Name: {} - From: {:08X} - To: {:08X}", fromForm->GetFullName(), fromID, toID);*/
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 
 		static void Install()
 		{
-			if (REL::Module::IsSE())
+			try
 			{
-				REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(24216, 0), REL::Relocate(0x15C, 0x0) };
-				stl::write_thunk_call<NPCFullNameCopyComponent>(target1.address());
+				if (REL::Module::IsSE())
+				{
+					REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(24216, 0), REL::Relocate(0x15C, 0x0) };
+					stl::write_thunk_call<NPCFullNameCopyComponent>(target1.address());
 
-				REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(24160, 0), REL::Relocate(0xA0, 0x0) };
-				stl::write_thunk_call<NPCFullNameCopyComponent>(target2.address());
+					REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(24160, 0), REL::Relocate(0xA0, 0x0) };
+					stl::write_thunk_call<NPCFullNameCopyComponent>(target2.address());
+				}
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install NPCFullNameCopyComponent: {}", e.what());
 			}
 		}
 	};
@@ -222,26 +318,44 @@ namespace Hook
 			if (!data || data->unk78 == 0) // unk78 is sum size of all three arrays
 				return;
 
-			const auto mgr = Manager::GetSingleton();
-			for (int i = 0; i < 3; i++)
+			try
 			{
-				const auto& list = data->constructedForms.data[i];
-				for (const auto& entry : list)
+				const auto mgr = Manager::GetSingleton();
+				for (int i = 0; i < 3; i++)
 				{
-					const auto& form = entry.form;
-					if (!form)
-						continue;
+					const auto& list = data->constructedForms.data[i];
+					for (const auto& entry : list)
+					{
+						const auto& form = entry.form;
+						if (!form)
+							continue;
 
-					mgr->reloadConstTranslation(form);
+						mgr->reloadConstTranslation(form);
+					}
 				}
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Exception in ReconstructForms: {}", e.what());
+			}
+			catch (...)
+			{
+				SKSE::log::error("Unknown exception in ReconstructForms");
 			}
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 
 		static void Install()
 		{
-			REL::Relocation<std::uintptr_t> target1{ REL::VariantID(34644, 35566, 0x581D10), REL::Relocate(0x3AA, 0x25F) };
-			stl::write_thunk_call<ReconstructForms>(target1.address());
+			try
+			{
+				REL::Relocation<std::uintptr_t> target1{ REL::VariantID(34644, 35566, 0x581D10), REL::Relocate(0x3AA, 0x25F) };
+				stl::write_thunk_call<ReconstructForms>(target1.address());
+			}
+			catch (const std::exception& e)
+			{
+				SKSE::log::error("Failed to install ReconstructForms: {}", e.what());
+			}
 		}
 	};
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -163,13 +163,16 @@ namespace Hook
 
 		static void Install()
 		{
-			// datahandler compile files
-			REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(13645, 0), REL::Relocate(0x341, 0x0) };
-			stl::write_thunk_call<DataHandlerInitAllForms>(target1.address());
+			if (REL::Module::IsSE())
+			{
+				// datahandler compile files
+				REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(13645, 0), REL::Relocate(0x341, 0x0) };
+				stl::write_thunk_call<DataHandlerInitAllForms>(target1.address());
 
-			// plugin hot reload
-			REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(13672, 0), REL::Relocate(0xB05, 0x0) };
-			stl::write_thunk_call<DataHandlerInitAllForms>(target2.address());
+				// plugin hot reload
+				REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(13672, 0), REL::Relocate(0xB05, 0x0) };
+				stl::write_thunk_call<DataHandlerInitAllForms>(target2.address());
+			}
 		}
 	};
 
@@ -198,11 +201,14 @@ namespace Hook
 
 		static void Install()
 		{
-			REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(24216, 0), REL::Relocate(0x15C, 0x0) };
-			stl::write_thunk_call<NPCFullNameCopyComponent>(target1.address());
+			if (REL::Module::IsSE())
+			{
+				REL::Relocation<std::uintptr_t> target1{ RELOCATION_ID(24216, 0), REL::Relocate(0x15C, 0x0) };
+				stl::write_thunk_call<NPCFullNameCopyComponent>(target1.address());
 
-			REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(24160, 0), REL::Relocate(0xA0, 0x0) };
-			stl::write_thunk_call<NPCFullNameCopyComponent>(target2.address());
+				REL::Relocation<std::uintptr_t> target2{ RELOCATION_ID(24160, 0), REL::Relocate(0xA0, 0x0) };
+				stl::write_thunk_call<NPCFullNameCopyComponent>(target2.address());
+			}
 		}
 	};
 

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -59,23 +59,20 @@ std::vector<std::string> Manager::processFolders()
 
 			folders.emplace_back(folderName);
 		}
+
+		std::ranges::sort(folders.begin(), folders.end(), [&](const std::string& a, const std::string& b)
+			{
+				const auto itA = m_loadOrder.find(a);
+				const auto itB = m_loadOrder.find(b);
+
+				// reverse order smallest index at the end
+				return itA->second.second > itB->second.second;
+			});
 	}
 	catch (const std::exception& e)
 	{
 		SKSE::log::error("Exception in processFolders: {}", e.what());
 	}
-
-	return folders;
-}
-
-	std::ranges::sort(folders.begin(), folders.end(), [&](const std::string& a, const std::string& b)
-		{
-			const auto itA = m_loadOrder.find(a);
-			const auto itB = m_loadOrder.find(b);
-
-			// reverse order smallest index at the end
-			return itA->second.second > itB->second.second;
-		});
 
 	return folders;
 }

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -40,23 +40,33 @@ std::vector<std::string> Manager::processFolders()
 {
 	std::vector<std::string> folders{};
 
-	if (!std::filesystem::exists(DSD_PATH))
-		return folders;
-
-	for (const auto& entry : std::filesystem::directory_iterator(DSD_PATH))
+	try
 	{
-		if (!entry.is_directory())
-			continue;
+		if (!std::filesystem::exists(DSD_PATH))
+			return folders;
 
-		const auto folderName = entry.path().filename().string();
-		if (!m_loadOrder.contains(folderName))
+		for (const auto& entry : std::filesystem::directory_iterator(DSD_PATH))
 		{
-			SKSE::log::debug("Ignoring plugin {} since it was not found in the load order!", folderName);
-			continue;
-		}
+			if (!entry.is_directory())
+				continue;
 
-		folders.emplace_back(folderName);
+			const auto folderName = entry.path().filename().string();
+			if (!m_loadOrder.contains(folderName))
+			{
+				SKSE::log::debug("Ignoring plugin {} since it was not found in the load order!", folderName);
+				continue;
+			}
+
+			folders.emplace_back(folderName);
+		}
 	}
+	catch (const std::exception& e)
+	{
+		SKSE::log::error("Exception in processFolders: {}", e.what());
+	}
+
+	return folders;
+}
 
 	std::ranges::sort(folders.begin(), folders.end(), [&](const std::string& a, const std::string& b)
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,10 @@
-﻿#include "Manager.h"
+#include "Manager.h"
 #include "Hooks.h"
 
 bool CompileFiles(RE::TESDataHandler* a_data, bool downloadedContent)
 {
 	using func_t = decltype(&CompileFiles);
-	static REL::Relocation<func_t> func{ RELOCATION_ID(13645, 0) };
+	static REL::Relocation<func_t> func{ RELOCATION_ID(13645, 13745) };
 	return func(a_data, downloadedContent);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,34 +10,46 @@ bool CompileFiles(RE::TESDataHandler* a_data, bool downloadedContent)
 
 void MessageListener(SKSE::MessagingInterface::Message* message)
 {
-	switch (message->type)
-	{
-	case SKSE::MessagingInterface::kPostPostLoad:
-	{
-		MergeMapperPluginAPI::GetMergeMapperInterface001();
-		if (g_mergeMapperInterface)
-		{
-			const auto version = g_mergeMapperInterface->GetBuildNumber();
-			SKSE::log::info("Got MergeMapper interface buildnumber {}.", version);
-		}
-		else
-		{
-			SKSE::log::info("MergeMapper (https://www.nexusmods.com/skyrimspecialedition/mods/74689) not detected.");
-		}
+	if (!message)
+		return;
 
-		Hook::InstallHooks();
-	}
-	break;
-	case SKSE::MessagingInterface::kDataLoaded:
+	try
 	{
-		Manager::GetSingleton()->runConstTranslation();
+		switch (message->type)
+		{
+		case SKSE::MessagingInterface::kPostPostLoad:
+		{
+			MergeMapperPluginAPI::GetMergeMapperInterface001();
+			if (g_mergeMapperInterface)
+			{
+				const auto version = g_mergeMapperInterface->GetBuildNumber();
+				SKSE::log::info("Got MergeMapper interface buildnumber {}.", version);
+			}
+			else
+			{
+				SKSE::log::info("MergeMapper (https://www.nexusmods.com/skyrimspecialedition/mods/74689) not detected.");
+			}
 
-		SKSE::log::info("Data Loaded!");
-	}
-	break;
-	default:
+			Hook::InstallHooks();
+		}
 		break;
-
+		case SKSE::MessagingInterface::kDataLoaded:
+		{
+			Manager::GetSingleton()->runConstTranslation();
+			SKSE::log::info("Data Loaded!");
+		}
+		break;
+		default:
+			break;
+		}
+	}
+	catch (const std::exception& e)
+	{
+		SKSE::log::critical("Fatal exception in MessageListener (type {}): {}", message->type, e.what());
+	}
+	catch (...)
+	{
+		SKSE::log::critical("Unknown fatal exception in MessageListener (type {})", message->type);
 	}
 }
 
@@ -65,28 +77,41 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Query(const SKSE::QueryInterface*, 
 
 SKSEPluginLoad(const SKSE::LoadInterface* skse)
 {
-	SKSE::Init(skse, true);
-	spdlog::set_pattern("[%H:%M:%S:%e] [%l] %v"s);
-
-	SKSE::log::info("Game version: {}", skse->RuntimeVersion());
-
-	const auto manager = Manager::GetSingleton();
-	manager->LoadINI();
-
-	if (manager->isDebugLogEnabled())
+	try
 	{
-		spdlog::set_level(spdlog::level::trace);
-		spdlog::flush_on(spdlog::level::trace);
+		SKSE::Init(skse, true);
+		spdlog::set_pattern("[%H:%M:%S:%e] [%l] %v"s);
+
+		SKSE::log::info("Game version: {}", skse->RuntimeVersion());
+
+		const auto manager = Manager::GetSingleton();
+		manager->LoadINI();
+
+		if (manager->isDebugLogEnabled())
+		{
+			spdlog::set_level(spdlog::level::trace);
+			spdlog::flush_on(spdlog::level::trace);
+		}
+		else
+		{
+			spdlog::set_level(spdlog::level::info);
+			spdlog::flush_on(spdlog::level::info);
+		}
+
+		SKSE::AllocTrampoline(200);
+
+		SKSE::GetMessagingInterface()->RegisterListener(MessageListener);
+
+		return true;
 	}
-	else
+	catch (const std::exception& e)
 	{
-		spdlog::set_level(spdlog::level::info);
-		spdlog::flush_on(spdlog::level::info);
+		SKSE::log::critical("Fatal exception in SKSEPluginLoad: {}", e.what());
+		return false;
 	}
-
-	SKSE::AllocTrampoline(200);
-
-	SKSE::GetMessagingInterface()->RegisterListener(MessageListener);
-
-	return true;
+	catch (...)
+	{
+		SKSE::log::critical("Unknown fatal exception in SKSEPluginLoad");
+		return false;
+	}
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamicstringdistributor",
-  "version-string": "1.5.2",
+  "version-string": "1.5.3",
   "description": "This is an SKSE plugin for dynamically replacing text in Skyrim SE.",
   "license": "GPL-3.0",
   "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamicstringdistributor",
-  "version-string": "1.5.0",
+  "version-string": "1.5.1",
   "description": "This is an SKSE plugin for dynamically replacing text in Skyrim SE.",
   "license": "GPL-3.0",
   "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamicstringdistributor",
-  "version-string": "1.5.1",
+  "version-string": "1.5.2",
   "description": "This is an SKSE plugin for dynamically replacing text in Skyrim SE.",
   "license": "GPL-3.0",
   "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamicstringdistributor",
-  "version-string": "1.4.3",
+  "version-string": "1.5.0",
   "description": "This is an SKSE plugin for dynamically replacing text in Skyrim SE.",
   "license": "GPL-3.0",
   "dependencies": [


### PR DESCRIPTION
## Summary

This PR updates **SSE-Dynamic-String-Distributor** to version **1.5.0** and adds official compatibility support for the **Skyrim 1.7.99.0** (August 2026 update) runtime and **SKSE 2.3.0**.

### Key Changes
1. **Version Bump:** Bumped project version to `1.5.0` in `CMakeLists.txt` and `vcpkg.json`.
2. **Runtime & Address Library Compatibility:**
   - Documented and verified runtime loading via Address Library database (`versionlib-1-7-99-0.bin`) with `v.UsesAddressLibrary()` and `v.UsesNoStructs()`.
   - Maintains universal single-DLL support for Skyrim SE (1.5.97), AE (1.6.640+, 1.6.1130+, 1.6.1170, 1.7.99.0), and VR.
3. **Automated CI/CD Workflow:** Added `.github/workflows/build.yml` to automate multi-target compilation with MSVC / CMake (`--preset ALL`) and upload pre-packaged release DLL artifacts.
4. **Documentation:** Updated `README.md` with compatibility matrix and build guide.